### PR TITLE
Ignore non deterministic wallets in the GUI

### DIFF
--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -149,6 +149,7 @@ export class GetWalletsResponseMeta {
   label: string;
   filename: string;
   encrypted: boolean;
+  type: string;
 }
 
 export class GetWalletsResponseEntry {

--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -53,6 +53,8 @@ export class ApiService {
   getWallets(): Observable<Wallet[]> {
     return this.get('wallets')
       .map((response: GetWalletsResponseWallet[]) => {
+        response = response.filter(wallet => wallet.meta.type === 'deterministic');
+
         const wallets: Wallet[] = [];
         response.forEach(wallet => {
           wallets.push(<Wallet> {


### PR DESCRIPTION
With this PR the GUI ignores all wallets that don't comply with `wallet.meta.type === 'deterministic'`. This solves the problem of the GUI showing Error 2. 