### PR TITLE
Allow wallets without addresses in the GUI

### DIFF
--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -55,21 +55,27 @@ export class ApiService {
       .map((response: GetWalletsResponseWallet[]) => {
         const wallets: Wallet[] = [];
         response.forEach(wallet => {
-          wallets.push(<Wallet> {
+          const processedWallet: Wallet = {
             label: wallet.meta.label,
             filename: wallet.meta.filename,
             coins: null,
             hours: null,
-            addresses: wallet.entries.map((entry: GetWalletsResponseEntry) => {
+            addresses: [],
+            encrypted: wallet.meta.encrypted,
+          };
+
+          if (wallet.entries) {
+            processedWallet.addresses = wallet.entries.map((entry: GetWalletsResponseEntry) => {
               return {
                 address: entry.address,
                 coins: null,
                 hours: null,
                 confirmed: true,
               };
-            }),
-            encrypted: wallet.meta.encrypted,
-          });
+            });
+          }
+
+          wallets.push(processedWallet);
         });
 
         return wallets;


### PR DESCRIPTION
Now the GUI is able to show wallets without addresses. With this change, empty collection wallets work in the UI (the addresses list is empty) and it is also possible to send coins with that type of wallets.

At the end, the UX does not appear to suffer a lot with this type of wallets, the only details are:
- The “New addresses” button shows an error message in the UI.
- The “Backup Wallet” page shows empty seeds for collection wallets.