### PR TITLE
Send "type=deterministic" when creating a wallet with the GUI

### DIFF
--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -87,8 +87,8 @@ export class ApiService {
       .map(response => response.seed);
   }
 
-  postWalletCreate(label: string, seed: string, scan: number, password: string): Observable<Wallet> {
-    const params = { label, seed, scan };
+  postWalletCreate(label: string, seed: string, scan: number, password: string, type: string): Observable<Wallet> {
+    const params = { label, seed, scan, type };
 
     if (password) {
       params['password'] = password;

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -100,7 +100,7 @@ export class WalletService {
   create(label, seed, scan, password) {
     seed = seed.replace(/(\n|\r\n)$/, '');
 
-    return this.apiService.postWalletCreate(label ? label : 'undefined', seed, scan ? scan : 100, password)
+    return this.apiService.postWalletCreate(label ? label : 'undefined', seed, scan ? scan : 100, password, 'deterministic')
       .do(wallet => {
         console.log(wallet);
         this.wallets.first().subscribe(wallets => {


### PR DESCRIPTION
With this PR the GUI sends `type=deterministic` to the API endpoint when creating a wallet.